### PR TITLE
2019 10 02 transactions

### DIFF
--- a/crates/sim1h/src/aspect/mod.rs
+++ b/crates/sim1h/src/aspect/mod.rs
@@ -1,16 +1,19 @@
 pub mod fixture;
-use holochain_json_api::json::JsonString;
-use std::time::UNIX_EPOCH;
-use std::time::SystemTime;
 use holochain_core_types::network::entry_aspect::EntryAspect;
-use lib3h_protocol::data_types::EntryAspectData;
+use holochain_json_api::json::JsonString;
 use holochain_persistence_api::cas::content::AddressableContent;
+use lib3h_protocol::data_types::EntryAspectData;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 pub fn entry_aspect_to_entry_aspect_data(entry_aspect: EntryAspect) -> EntryAspectData {
     EntryAspectData {
         aspect_address: entry_aspect.address(),
         type_hint: entry_aspect.type_hint(),
         aspect: JsonString::from(entry_aspect).to_bytes().into(),
-        publish_ts: SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_millis() as u64,
+        publish_ts: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_millis() as u64,
     }
 }

--- a/crates/sim1h/src/dht/bbdht/dynamodb/api/agent/inbox.rs
+++ b/crates/sim1h/src/dht/bbdht/dynamodb/api/agent/inbox.rs
@@ -1,7 +1,5 @@
 use crate::dht::bbdht::dynamodb::api::item::Item;
 use crate::dht::bbdht::dynamodb::client::Client;
-use crate::dht::bbdht::dynamodb::schema::{blob_attribute_value, bool_attribute_value};
-use crate::dht::bbdht::dynamodb::schema::cas::{inbox_key, MESSAGE_IS_RESPONSE_KEY};
 use crate::dht::bbdht::dynamodb::schema::cas::ADDRESS_KEY;
 use crate::dht::bbdht::dynamodb::schema::cas::MESSAGE_CONTENT_KEY;
 use crate::dht::bbdht::dynamodb::schema::cas::MESSAGE_FROM_KEY;
@@ -9,9 +7,11 @@ use crate::dht::bbdht::dynamodb::schema::cas::MESSAGE_SPACE_ADDRESS_KEY;
 use crate::dht::bbdht::dynamodb::schema::cas::MESSAGE_TO_KEY;
 use crate::dht::bbdht::dynamodb::schema::cas::REQUEST_IDS_KEY;
 use crate::dht::bbdht::dynamodb::schema::cas::REQUEST_IDS_SEEN_KEY;
+use crate::dht::bbdht::dynamodb::schema::cas::{inbox_key, MESSAGE_IS_RESPONSE_KEY};
 use crate::dht::bbdht::dynamodb::schema::string_attribute_value;
 use crate::dht::bbdht::dynamodb::schema::string_set_attribute_value;
 use crate::dht::bbdht::dynamodb::schema::TableName;
+use crate::dht::bbdht::dynamodb::schema::{blob_attribute_value, bool_attribute_value};
 use crate::dht::bbdht::error::BbDhtError;
 use crate::dht::bbdht::error::BbDhtResult;
 use crate::trace::tracer;
@@ -357,13 +357,16 @@ pub fn item_to_direct_message_data(item: &Item) -> BbDhtResult<(DirectMessageDat
         }
     };
 
-    Ok((DirectMessageData {
-        content: content.into(),
-        from_agent_id: from_agent_id.into(),
-        to_agent_id: to_agent_id.into(),
-        request_id: request_id,
-        space_address: space_address.into(),
-    }, is_response))
+    Ok((
+        DirectMessageData {
+            content: content.into(),
+            from_agent_id: from_agent_id.into(),
+            to_agent_id: to_agent_id.into(),
+            request_id: request_id,
+            space_address: space_address.into(),
+        },
+        is_response,
+    ))
 }
 
 pub fn request_ids_to_messages(

--- a/crates/sim1h/src/dht/bbdht/dynamodb/api/agent/inbox.rs
+++ b/crates/sim1h/src/dht/bbdht/dynamodb/api/agent/inbox.rs
@@ -277,6 +277,7 @@ pub fn get_inbox_request_ids(
     );
     let get_item_output = client
         .get_item(GetItemInput {
+            consistent_read: Some(true),
             table_name: table_name.into(),
             key: key,
             ..Default::default()
@@ -384,6 +385,7 @@ pub fn request_ids_to_messages(
 
         let get_item_output = client
             .get_item(GetItemInput {
+                consistent_read: Some(true),
                 table_name: table_name.into(),
                 key: key,
                 ..Default::default()

--- a/crates/sim1h/src/dht/bbdht/dynamodb/api/agent/write.rs
+++ b/crates/sim1h/src/dht/bbdht/dynamodb/api/agent/write.rs
@@ -1,3 +1,4 @@
+use crate::dht::bbdht::dynamodb::api::item::write::should_put_item_retry;
 use crate::dht::bbdht::dynamodb::client::Client;
 use crate::dht::bbdht::dynamodb::schema::cas::ADDRESS_KEY;
 use crate::dht::bbdht::dynamodb::schema::string_attribute_value;
@@ -9,7 +10,6 @@ use holochain_persistence_api::cas::content::Address;
 use rusoto_dynamodb::DynamoDb;
 use rusoto_dynamodb::PutItemInput;
 use std::collections::HashMap;
-use crate::dht::bbdht::dynamodb::api::item::write::should_put_item_retry;
 
 pub fn touch_agent(
     log_context: &LogContext,
@@ -27,15 +27,16 @@ pub fn touch_agent(
 
     if should_put_item_retry(
         log_context,
-        client.put_item(PutItemInput {
-        table_name: table_name.to_string(),
-        item: item,
-        ..Default::default()
-    })
-    .sync())? {
+        client
+            .put_item(PutItemInput {
+                table_name: table_name.to_string(),
+                item: item,
+                ..Default::default()
+            })
+            .sync(),
+    )? {
         touch_agent(log_context, client, table_name, agent_id)
-    }
-    else {
+    } else {
         Ok(())
     }
 }

--- a/crates/sim1h/src/dht/bbdht/dynamodb/api/aspect/read.rs
+++ b/crates/sim1h/src/dht/bbdht/dynamodb/api/aspect/read.rs
@@ -152,6 +152,7 @@ pub fn scan_aspects(
 ) -> BbDhtResult<(AspectAddressMap, Option<Item>)> {
     client
         .scan(ScanInput {
+            consistent_read: Some(true),
             table_name: table_name.to_string(),
             projection_expression: projection_expression(vec![ADDRESS_KEY, ASPECT_LIST_KEY]),
             exclusive_start_key,

--- a/crates/sim1h/src/dht/bbdht/dynamodb/api/aspect/write.rs
+++ b/crates/sim1h/src/dht/bbdht/dynamodb/api/aspect/write.rs
@@ -1,3 +1,4 @@
+use crate::dht::bbdht::dynamodb::api::item::write::should_put_item_retry;
 use crate::dht::bbdht::dynamodb::client::Client;
 use crate::dht::bbdht::dynamodb::schema::blob_attribute_value;
 use crate::dht::bbdht::dynamodb::schema::cas::ADDRESS_KEY;
@@ -11,7 +12,6 @@ use crate::dht::bbdht::dynamodb::schema::string_attribute_value;
 use crate::dht::bbdht::dynamodb::schema::string_set_attribute_value;
 use crate::dht::bbdht::dynamodb::schema::TableName;
 use crate::dht::bbdht::error::BbDhtResult;
-use crate::dht::bbdht::dynamodb::api::item::write::should_put_item_retry;
 use crate::trace::tracer;
 use crate::trace::LogContext;
 use holochain_persistence_api::cas::content::Address;
@@ -67,15 +67,16 @@ pub fn put_aspect(
 
     if should_put_item_retry(
         log_context,
-        client.put_item(PutItemInput {
-        table_name: table_name.to_string(),
-        item: aspect_item,
-        ..Default::default()
-    })
-    .sync())? {
+        client
+            .put_item(PutItemInput {
+                table_name: table_name.to_string(),
+                item: aspect_item,
+                ..Default::default()
+            })
+            .sync(),
+    )? {
         put_aspect(log_context, client, table_name, aspect)
-    }
-    else {
+    } else {
         Ok(())
     }
 }

--- a/crates/sim1h/src/dht/bbdht/dynamodb/api/item/read.rs
+++ b/crates/sim1h/src/dht/bbdht/dynamodb/api/item/read.rs
@@ -25,6 +25,7 @@ pub fn get_item_by_address(
     );
     Ok(client
         .get_item(GetItemInput {
+            consistent_read: Some(true),
             table_name: table_name.into(),
             key: key,
             ..Default::default()

--- a/crates/sim1h/src/dht/bbdht/dynamodb/api/item/write.rs
+++ b/crates/sim1h/src/dht/bbdht/dynamodb/api/item/write.rs
@@ -89,7 +89,7 @@ pub fn ensure_content(
 ) -> BbDhtResult<()> {
     tracer(&log_context, "ensure_content");
 
-    let retry = should_put_item_retry(
+    if should_put_item_retry(
         log_context,
         client
             .put_item(PutItemInput {
@@ -97,10 +97,8 @@ pub fn ensure_content(
                 table_name: table_name.to_string(),
                 ..Default::default()
             })
-            .sync(),
-    )?;
-
-    if retry {
+            .sync()
+    )? {
         ensure_content(log_context, client, table_name, content)
     } else {
         Ok(())

--- a/crates/sim1h/src/dht/bbdht/dynamodb/api/item/write.rs
+++ b/crates/sim1h/src/dht/bbdht/dynamodb/api/item/write.rs
@@ -8,12 +8,12 @@ use crate::dht::bbdht::error::BbDhtResult;
 use crate::trace::tracer;
 use crate::trace::LogContext;
 use holochain_persistence_api::cas::content::AddressableContent;
-use rusoto_dynamodb::DynamoDb;
-use rusoto_dynamodb::PutItemInput;
-use std::collections::HashMap;
-use rusoto_dynamodb::PutItemError;
-use rusoto_dynamodb::PutItemOutput;
 use rusoto_core::RusotoError;
+use rusoto_dynamodb::DynamoDb;
+use rusoto_dynamodb::PutItemError;
+use rusoto_dynamodb::PutItemInput;
+use rusoto_dynamodb::PutItemOutput;
+use std::collections::HashMap;
 
 pub fn content_to_item(content: &dyn AddressableContent) -> Item {
     let mut item = HashMap::new();
@@ -97,7 +97,7 @@ pub fn ensure_content(
                 table_name: table_name.to_string(),
                 ..Default::default()
             })
-            .sync()
+            .sync(),
     )? {
         ensure_content(log_context, client, table_name, content)
     } else {

--- a/crates/sim1h/src/dht/bbdht/dynamodb/api/item/write.rs
+++ b/crates/sim1h/src/dht/bbdht/dynamodb/api/item/write.rs
@@ -9,15 +9,10 @@ use crate::trace::LogContext;
 use holochain_persistence_api::cas::content::AddressableContent;
 use rusoto_dynamodb::DynamoDb;
 use rusoto_dynamodb::PutItemInput;
+use crate::dht::bbdht::dynamodb::api::item::Item;
 use std::collections::HashMap;
 
-pub fn ensure_content(
-    log_context: &LogContext,
-    client: &Client,
-    table_name: &TableName,
-    content: &dyn AddressableContent,
-) -> BbDhtResult<()> {
-    tracer(&log_context, "ensure_content");
+pub fn content_to_item(content: &dyn AddressableContent) -> Item {
     let mut item = HashMap::new();
     item.insert(
         String::from(ADDRESS_KEY),
@@ -27,10 +22,20 @@ pub fn ensure_content(
         String::from(CONTENT_KEY),
         string_attribute_value(&String::from(content.content())),
     );
+    item
+}
+
+pub fn ensure_content(
+    log_context: &LogContext,
+    client: &Client,
+    table_name: &TableName,
+    content: &dyn AddressableContent,
+) -> BbDhtResult<()> {
+    tracer(&log_context, "ensure_content");
 
     client
         .put_item(PutItemInput {
-            item: item,
+            item: content_to_item(content),
             table_name: table_name.to_string(),
             ..Default::default()
         })
@@ -47,7 +52,56 @@ pub mod tests {
     use crate::dht::bbdht::dynamodb::api::table::exist::table_exists;
     use crate::dht::bbdht::dynamodb::api::table::fixture::table_name_fresh;
     use crate::dht::bbdht::dynamodb::client::local::local_client;
+    use crate::dht::bbdht::dynamodb::api::item::write::content_to_item;
+    use rusoto_dynamodb::DynamoDb;
+    use rusoto_dynamodb::Put;
+    use rusoto_dynamodb::TransactWriteItemsInput;
+    use rusoto_dynamodb::TransactWriteItem;
     use crate::trace::tracer;
+
+    #[test]
+    /// older versions of dynamodb don't support transact writes
+    /// test that this version is supported
+    fn transact_write_item_test() {
+        let log_context = "transact_write_item_test";
+
+        tracer(&log_context, "fixtures");
+        let local_client = local_client();
+        let table_name = table_name_fresh();
+        let content_a = content_fresh();
+        let content_b = content_fresh();
+
+        // ensure cas
+        assert!(ensure_cas_table(&log_context, &local_client, &table_name).is_ok());
+
+        // cas exists
+        assert!(table_exists(&log_context, &local_client, &table_name)
+        .expect("could not check table exists"));
+
+        // transact
+        local_client.transact_write_items(TransactWriteItemsInput {
+            transact_items: vec![
+                TransactWriteItem {
+                    put: Some(Put {
+                        table_name: table_name.clone(),
+                        item: content_to_item(&content_a),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                TransactWriteItem {
+                    put: Some(Put {
+                        table_name: table_name.clone(),
+                        item: content_to_item(&content_b),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }
+            ],
+            ..Default::default()
+        }).sync().expect("could not transact write items");
+
+    }
 
     #[test]
     fn ensure_content_test() {

--- a/crates/sim1h/src/workflow/from_client/bootstrap.rs
+++ b/crates/sim1h/src/workflow/from_client/bootstrap.rs
@@ -1,9 +1,9 @@
 use crate::dht::bbdht::dynamodb::account::describe_limits;
 use crate::dht::bbdht::dynamodb::client::Client;
+use crate::dht::bbdht::error::BbDhtResult;
 use crate::trace::tracer;
 use crate::trace::LogContext;
 use lib3h_protocol::protocol::ClientToLib3hResponse;
-use crate::dht::bbdht::error::BbDhtResult;
 
 /// check database connection
 /// optional

--- a/crates/sim1h/src/workflow/from_client/fetch_entry.rs
+++ b/crates/sim1h/src/workflow/from_client/fetch_entry.rs
@@ -1,4 +1,5 @@
 use crate::dht::bbdht::dynamodb::client::Client;
+use crate::dht::bbdht::error::BbDhtResult;
 use crate::trace::LogContext;
 use crate::workflow::from_client::query_entry::query_entry_aspects;
 use holochain_core_types::network::query::NetworkQuery;
@@ -8,7 +9,6 @@ use lib3h_protocol::data_types::FetchEntryData;
 use lib3h_protocol::data_types::FetchEntryResultData;
 use lib3h_protocol::data_types::QueryEntryData;
 use lib3h_protocol::protocol::ClientToLib3hResponse;
-use crate::dht::bbdht::error::BbDhtResult;
 
 /// MVP (needs tests, wrapping query atm)
 /// query entry but hardcoded to entry query right?

--- a/crates/sim1h/src/workflow/from_client/leave_space.rs
+++ b/crates/sim1h/src/workflow/from_client/leave_space.rs
@@ -1,9 +1,9 @@
 use crate::dht::bbdht::dynamodb::client::Client;
+use crate::dht::bbdht::error::BbDhtResult;
 use crate::trace::tracer;
 use crate::trace::LogContext;
 use lib3h_protocol::data_types::SpaceData;
 use lib3h_protocol::protocol::ClientToLib3hResponse;
-use crate::dht::bbdht::error::BbDhtResult;
 
 /// no-op
 pub fn leave_space(

--- a/crates/sim1h/src/workflow/from_client/send_direct_message.rs
+++ b/crates/sim1h/src/workflow/from_client/send_direct_message.rs
@@ -1,10 +1,10 @@
 use crate::dht::bbdht::dynamodb::api::agent::inbox::send_to_agent_inbox;
 use crate::dht::bbdht::dynamodb::client::Client;
+use crate::dht::bbdht::error::BbDhtResult;
 use crate::trace::tracer;
 use crate::trace::LogContext;
 use lib3h_protocol::data_types::DirectMessageData;
 use lib3h_protocol::protocol::ClientToLib3hResponse;
-use crate::dht::bbdht::error::BbDhtResult;
 
 /// A: append message to inbox in database
 pub fn send_direct_message(

--- a/dynamodb/default.nix
+++ b/dynamodb/default.nix
@@ -5,8 +5,8 @@ let
   name = name;
 
   src = pkgs.fetchurl {
-   url = "https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_test_2018-03-23/dynamodb_local_latest.tar.gz";
-   sha256 = "0wzp07wdmay4kdc31fs14rbpwch0ncq6zsl7yl3vfa0rk9klgx9x";
+   url = "https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_2019-02-07.tar.gz";
+   sha256 = "0hrwxg4igyll40y7l1s0icg55g247fl8cjs4rrcpjf8d7m0bb09j";
   };
 
   nativeBuildInputs = [ pkgs.makeWrapper ];


### PR DESCRIPTION
various things to make things more ACID-ish

- set `consistent_read` to `true` for all `GetItemInput` and `ScanInput` (forces reads to track writes as they happen)
- use a newer version of local dynamodb that supports transactions for writes (atomic all write or all fail)
- standardise `should_put_item_retry` brute force looping retry logic for puts

originally i was planning to rewrite all things that happen "together" into transactions because we were seeing flakiness in app spec

i tried a different approach here (which is not wholly incompatible with transactions if we want to try that later) because:

- i'm not convinced that transactions will fix anything if the problem is eventual consistency of reads
  - atomic writes are only relevant to write fails not write successes
  - we always write our items/aspects/messages out before adding new references to them, and have an append-only data model, so it should not be possible for reads that follow references to discover a missing successful write, regardless of any transactions model
  - the default _read_ model is eventual consistency (this is what we are doing) so even if writes are perfect there is a delay of up to a few seconds before reads see them by default _but_ there is a configurable strong consistency option that we can try that guarantees reads track writes as they happen, this supports both `get` and `scan` operations
- transactions have a limit of 10 put/write/delete actions per transaction, while a loop over e.g. a vector of aspects has no such limit, which means that the best we can do with transactions is some kind of bulk pagination which is still not 100% bulletproof, which suggests that transactions aren't the right approach to make something totally rock solid in general
- the rusoto crate sets up transactions as a 3 level nested beast of a struct like `Transactions -> Transaction -> Put/Delete/Update` which makes things much more awkward to factor out than the current code that just loops over a simple, standard `put` operation
  - IMO conceptually it's much harder to track different actions that are only tangentially related other than their transaction-ey-ness (e.g. write message content vs. lodge new "unseen" message id) when lumped into a single struct vs. split by function and co-ordinated by lexical ordering

so this approach is to disable the eventual consistency of reads and standardise retry logic of puts to try and ride out internal server errors and temporary throughput issues better